### PR TITLE
Update GH Actions used, and mention version auditing in README.md

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,9 +9,9 @@ jobs:
         shell: bash -l {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: '3.10'
 

--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@
 Template repository based on the [CPG team-docs](https://github.com/populationgenomics/team-docs/blob/main/new_repository.md) content.
 
 This contains python and markdown linting configuration, and a github linting action.
+Before making a new repository based on this template, it may be worth auditing the versions of linting tools and GitHub Actions listed in _.pre-commit-config.yaml_ and _.github/workflows_.


### PR DESCRIPTION
Update template from outdated node12-based actions to their current 16- and 20-based releases.

Add a note about checking these before using the template — see https://centrepopgen.slack.com/archives/C018KFBCR1C/p1698187914059699 for context.