### PR TITLE
Bump pre-commit versions + add isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3.11
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.5.0
     hooks:
       - id: check-yaml
         exclude: '\.*conda/.*'
@@ -16,24 +16,38 @@ repos:
       - id: check-added-large-files
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.31.1
+    rev: v0.38.0
     hooks:
       - id: markdownlint
-        args: ["--config", ".markdownlint.json"]
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
 
   - repo: https://github.com/ambv/black
-    rev: "22.3.0"
+    rev: 23.12.1
     hooks:
       - id: black
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.1.0
+    rev: v0.1.11
     hooks:
       - id: ruff
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v0.960"
+    rev: v1.8.0
     hooks:
       - id: mypy
+        args:
+          [
+            --pretty,
+            --show-error-codes,
+            --no-strict-optional,
+            --ignore-missing-imports,
+            --install-types,
+            --non-interactive,
+          ]
         additional_dependencies: [types-PyYAML==6.0.4, types-toml]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ skip-string-normalization = true
 
 [tool.isort]
 py_version = 311
+profile = "black"
 
 [tool.ruff]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,25 @@ skip-string-normalization = true
 [tool.isort]
 py_version = 311
 profile = "black"
+line_length = 88
+sections = ["FUTURE", "STDLIB", "THIRDPARTY", "HAIL", "CPG", "FIRSTPARTY", "LOCALFOLDER"]
+known_hail = [
+    "hail",
+    "hailtop",
+]
+# Adjust these for each repository, e.g., removing those that should be
+# local rather than CPG. Also fill in extend_skip below if there are any
+# subdirectories that should be ignored.
+known_cpg = [
+    "analysis_runner",
+    "cpg_infra",
+    "cpg_utils",
+    "cpg_workflows",
+    "gnomad",
+    "hail_scripts",
+    "metamist",
+]
+# extend_skip = ["list", "submodules", "etc", here"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Happy new time to bump versions of our pre-commits - it's truly the most magical time of the year.

This time, a new friend `isort`. It's mostly enabled in vscode now, already in our `pyproject.toml`, so time to make things official.